### PR TITLE
Fix notebook import path

### DIFF
--- a/utils/divider.ipynb
+++ b/utils/divider.ipynb
@@ -7,7 +7,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from rounding import resistor_divider, prefix, sig_figs\n",
+    "from utils.rounding import resistor_divider, prefix, sig_figs\n",
     "\n",
     "V_in=170\n",
     "V_out=1\n",


### PR DESCRIPTION
## Summary
- fix the import path in `utils/divider.ipynb` so it can run from repo root

## Testing
- `pytest -q`