### PR TITLE
Add converter modules and unit tests

### DIFF
--- a/boost-converter/LM3478MM_design.ipynb
+++ b/boost-converter/LM3478MM_design.ipynb
@@ -9,6 +9,7 @@
    "source": [
     "from utils import rounding\n",
     "import math"
+    "from boost_converter import lm3478"
    ]
   },
   {
@@ -49,7 +50,7 @@
    "source": [
     "# Duty cycle\n",
     "\n",
-    "D = 1 - (V_in_nom - V_q) / (V_out + V_f)\n",
+    "D = lm3478.duty_cycle(V_in_nom, V_out, V_q, V_f)\n",
     "print(f'Design duty cycle (CCM) = {rounding.sig_figs(D*100,4)}%')"
    ]
   },
@@ -62,7 +63,7 @@
    "source": [
     "# Inductor sizing\n",
     "\n",
-    "L_CCM = D*(1-D)*V_in_nom/(2*f_sw*I_out_nom)\n",
+    "L_CCM = lm3478.min_inductor_ccm(D, V_in_nom, f_sw, I_out_nom)\n",
     "print(f'Minimum inductor size to support CCM = {rounding.prefix(L_CCM)}H')\n",
     "\n",
     "I_L = I_out_nom / (1-D) # Average inductor current (A)\n",
@@ -74,7 +75,7 @@
     "print(f'Inductor valley current = {rounding.prefix(I_L_valley)}A')\n",
     "print(f'Inductor ripple current = {rounding.prefix(I_ripple)}A')\n",
     "\n",
-    "L_ripple = D*V_in_nom/(2*f_sw*I_ripple)\n",
+    "L_ripple = lm3478.inductor_value_for_ripple(V_in_nom, D, f_sw, I_ripple)\n",
     "print(f'Minimum inductor size for design ripple ratio ({ripple_ratio*100}%) = {rounding.prefix(L_ripple)}H')"
    ]
   },
@@ -269,7 +270,7 @@
    "source": [
     "# Diode selection\n",
     "\n",
-    "I_D_peak = I_L_peak - D*I_out_nom\n",
+    "I_D_peak = lm3478.diode_peak_current(I_L_peak, D, I_out_nom)\n",
     "\n",
     "print(f'Diode peak current at nominal input/output = {rounding.prefix(I_D_peak)}A')"
    ]

--- a/boost-converter/__init__.py
+++ b/boost-converter/__init__.py
@@ -1,0 +1,5 @@
+"""Boost converter design utilities."""
+
+from . import lm3478
+
+__all__ = ["lm3478"]

--- a/boost-converter/lm3478.py
+++ b/boost-converter/lm3478.py
@@ -1,0 +1,53 @@
+"""Design formulas for the LM3478 boost converter."""
+
+import math
+
+
+def duty_cycle(V_in: float, V_out: float, V_q: float = 0.0, V_f: float = 0.0) -> float:
+    """Calculate continuous conduction mode duty cycle."""
+    return 1 - (V_in - V_q) / (V_out + V_f)
+
+
+def min_inductor_ccm(D: float, V_in: float, f_sw: float, I_out: float) -> float:
+    """Minimum inductance to maintain CCM."""
+    return D * (1 - D) * V_in / (2 * f_sw * I_out)
+
+
+def inductor_ripple_current(V_in: float, D: float, f_sw: float, L: float) -> float:
+    """Inductor ripple current."""
+    return D * V_in / (2 * f_sw * L)
+
+
+def inductor_value_for_ripple(V_in: float, D: float, f_sw: float, I_ripple: float) -> float:
+    """Inductor value required for a given ripple current."""
+    return D * V_in / (2 * f_sw * I_ripple)
+
+
+def diode_peak_current(I_L_peak: float, D: float, I_out: float) -> float:
+    """Peak diode current."""
+    return I_L_peak - D * I_out
+
+
+def sense_resistor(V_sense: float, ratio_V_sl: float, I_limit: float, D: float) -> float:
+    """Calculate sense resistor value for a desired current limit."""
+    return (V_sense - (D * V_sense * ratio_V_sl)) / I_limit
+
+
+def sense_resistor_limit(V_sl: float, f_sw: float, L: float, V_out: float, V_in: float) -> float:
+    """Maximum sense resistor before external slope compensation is required."""
+    return (2 * V_sl * f_sw * L) / (V_out - 2 * V_in)
+
+
+def mosfet_losses(I_L: float, I_L_peak: float, I_L_valley: float, D: float, V_out: float,
+                  R_ds_on: float, temp_factor: float, t_LH: float, t_HL: float, f_sw: float) -> tuple:
+    """Return MOSFET conduction and switching losses."""
+    P_cond = I_L ** 2 * R_ds_on * temp_factor * D
+    P_sw = 0.5 * I_L_peak * V_out * t_LH * f_sw + 0.5 * I_L_valley * V_out * t_HL * f_sw
+    return P_cond, P_sw, P_cond + P_sw
+
+
+def capacitor_rms_currents(I_ripple: float, D: float, I_out: float) -> tuple:
+    """Return input and output capacitor RMS currents."""
+    I_cin = I_ripple / math.sqrt(3)
+    I_cout = math.sqrt((1 - D) * ((I_out ** 2 * D / (1 - D)) + I_ripple ** 2 / 3))
+    return I_cin, I_cout

--- a/boost_converter/__init__.py
+++ b/boost_converter/__init__.py
@@ -1,0 +1,7 @@
+from importlib import import_module
+
+# Alias package to allow importing boost_converter.lm3478
+_pkg = import_module('boost-converter')
+
+lm3478 = _pkg.lm3478
+__all__ = ['lm3478']

--- a/flyback-converter/LT8300_design.ipynb
+++ b/flyback-converter/LT8300_design.ipynb
@@ -9,6 +9,7 @@
    "source": [
     "import sympy as sp\n",
     "from utils import rounding as rnd"
+    "from flyback_converter import lt8300"
    ]
   },
   {

--- a/flyback-converter/__init__.py
+++ b/flyback-converter/__init__.py
@@ -1,0 +1,5 @@
+"""Flyback converter design utilities."""
+
+from . import lt8300
+
+__all__ = ["lt8300"]

--- a/flyback-converter/lt8300.py
+++ b/flyback-converter/lt8300.py
@@ -1,0 +1,26 @@
+"""Design formulas for LT8300-based flyback converters."""
+
+
+def feedback_resistor(V_out: float, V_f: float, I_Rfb: float, N_ps: float) -> float:
+    """Calculate feedback resistor from output voltage and turns ratio."""
+    return N_ps * (V_out + V_f) / I_Rfb
+
+
+def duty_cycle(V_in: float, V_out: float, V_f: float, N_ps: float) -> float:
+    """Switch duty cycle."""
+    return (V_out + V_f) * N_ps / ((V_out + V_f) * N_ps + V_in)
+
+
+def output_power(V_in: float, eta: float, D: float, I_sw_max: float) -> float:
+    """Maximum output power."""
+    return eta * V_in * D * I_sw_max * 0.5
+
+
+def primary_inductance_min_off(N_ps: float, V_out: float, V_f: float, t_off_min: float, I_sw_min: float) -> float:
+    """Minimum primary inductance due to minimum off time."""
+    return t_off_min * N_ps * (V_out + V_f) / I_sw_min
+
+
+def primary_inductance_min_on(V_in: float, t_on_min: float, I_sw_min: float) -> float:
+    """Minimum primary inductance due to minimum on time."""
+    return t_on_min * V_in / I_sw_min

--- a/flyback_converter/__init__.py
+++ b/flyback_converter/__init__.py
@@ -1,0 +1,6 @@
+from importlib import import_module
+
+_pkg = import_module('flyback-converter')
+
+lt8300 = _pkg.lt8300
+__all__ = ['lt8300']

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -1,0 +1,25 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import math
+from boost_converter import lm3478
+from flyback_converter import lt8300
+
+
+def test_lm3478_duty_cycle():
+    d = lm3478.duty_cycle(40, 480, 0.300, 1.2)
+    assert math.isclose(d, 0.9174979, rel_tol=1e-6)
+
+
+def test_lm3478_inductor_value_for_ripple():
+    val = lm3478.inductor_value_for_ripple(40, 0.9, 250e3, 0.1)
+    assert math.isclose(val, 7.2e-4, rel_tol=1e-2)
+
+
+def test_lt8300_duty_cycle():
+    d = lt8300.duty_cycle(12, 400, 1.45, 0.1)
+    assert math.isclose(d, 0.76987247, rel_tol=1e-6)
+
+
+def test_lt8300_feedback_resistor():
+    r = lt8300.feedback_resistor(400, 1.45, 100e-6, 0.1)
+    assert math.isclose(r, 401450.0, rel_tol=1e-6)


### PR DESCRIPTION
## Summary
- implement LM3478 and LT8300 design formulas as Python modules
- export convenience alias packages `boost_converter` and `flyback_converter`
- reference new modules in notebooks
- add tests for converter formulas

## Testing
- `pytest -q`