### PR TITLE
Move flyback calculations to topology module

### DIFF
--- a/controllers/__init__.py
+++ b/controllers/__init__.py
@@ -44,7 +44,7 @@ LT8300 = Controller(
 LM5156 = Controller(
     name="LM5156",
     topologies=("boost", "flyback",),
-    v_ref=1.0,
+    V_ref=1.0,
     V_sense=100e-3,
     f_sw_range=(100e3, 2.2e6),
 )

--- a/flyback_converter/from_pdf.py
+++ b/flyback_converter/from_pdf.py
@@ -6,50 +6,16 @@ Compute boundary and steady-state parameters for a flyback converter
 in DCM and CCM, per the equations in the Flyback.pdf (stades Flyback DCM2).
 """
 
-import math
 import argparse
-
-def boundary_duty_cycle(Vin, Vout, Nps):
-    """
-    D_BOUND = Nps * Vout / (Nps * Vout + Vin)
-    """
-    return (Nps * Vout) / (Nps * Vout + Vin)
-
-def dt_cycle(D, Fsw):
-    """
-    dt = D / F_sw
-    """
-    return D / Fsw
-
-def peak_current(Vin, Lp, D, Fsw):
-    """
-    I_PK = (Vin/Lp) * dt = Vin * D / (Lp * Fsw)
-    """
-    return Vin * D / (Lp * Fsw)
-
-def energy_inductor(Lp, Ipk):
-    """
-    E = 1/2 * Lp * Ipk^2
-    """
-    return 0.5 * Lp * Ipk**2
-
-def boundary_power(Vin, D, Lp, Fsw):
-    """
-    P_BOUNDARY = Vin^2 * D^2 / (2 * Lp * Fsw)
-    """
-    return Vin**2 * D**2 / (2 * Lp * Fsw)
-
-def voltage_ratio_DCM(D, Rload, Lp, Fsw):
-    """
-    Vout/Vin (DCM) = D * sqrt(Rload / (2 * Lp * Fsw))
-    """
-    return D * math.sqrt(Rload / (2 * Lp * Fsw))
-
-def voltage_ratio_CCM(D, Nps):
-    """
-    Vout/Vin (CCM) = (D / Nps) / (1 - D)
-    """
-    return (D / Nps) / (1 - D)
+from topologies.flyback import (
+    boundary_duty_cycle,
+    dt_cycle,
+    peak_current,
+    energy_inductor,
+    boundary_power,
+    voltage_ratio_DCM,
+    voltage_ratio_CCM,
+)
 
 def main():
     p = argparse.ArgumentParser(description="Flyback converter boundary & ratio calcs")

--- a/topologies/flyback.py
+++ b/topologies/flyback.py
@@ -1,6 +1,7 @@
 """Generic flyback-converter design equations."""
 
 from controllers import Controller
+import math
 
 
 def feedback_resistor(controller: Controller, V_out: float, V_f: float, N_ps: float) -> float:
@@ -34,3 +35,52 @@ def primary_inductance_min_on(controller: Controller, V_in: float) -> float:
     if controller.t_on_min is None or controller.I_sw_min is None:
         raise ValueError("Controller lacks t_on_min or I_sw_min")
     return controller.t_on_min * V_in / controller.I_sw_min
+
+
+def boundary_duty_cycle(Vin, Vout, Nps):
+    """
+    D_BOUND = Nps * Vout / (Nps * Vout + Vin)
+    """
+    return (Nps * Vout) / (Nps * Vout + Vin)
+
+
+def dt_cycle(D, Fsw):
+    """
+    dt = D / F_sw
+    """
+    return D / Fsw
+
+
+def peak_current(Vin, Lp, D, Fsw):
+    """
+    I_PK = (Vin/Lp) * dt = Vin * D / (Lp * Fsw)
+    """
+    return Vin * D / (Lp * Fsw)
+
+
+def energy_inductor(Lp, Ipk):
+    """
+    E = 1/2 * Lp * Ipk^2
+    """
+    return 0.5 * Lp * Ipk**2
+
+
+def boundary_power(Vin, D, Lp, Fsw):
+    """
+    P_BOUNDARY = Vin^2 * D^2 / (2 * Lp * Fsw)
+    """
+    return Vin**2 * D**2 / (2 * Lp * Fsw)
+
+
+def voltage_ratio_DCM(D, Rload, Lp, Fsw):
+    """
+    Vout/Vin (DCM) = D * sqrt(Rload / (2 * Lp * Fsw))
+    """
+    return D * math.sqrt(Rload / (2 * Lp * Fsw))
+
+
+def voltage_ratio_CCM(D, Nps):
+    """
+    Vout/Vin (CCM) = (D / Nps) / (1 - D)
+    """
+    return (D / Nps) / (1 - D)


### PR DESCRIPTION
## Summary
- centralize flyback calculation helpers in `topologies.flyback`
- update `from_pdf.py` to use shared helpers
- fix typo in `LM5156` controller definition

## Testing
- `pytest -q`