### PR TITLE
Add CLAUDE.md: always commit regenerated artifacts after a test

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,22 @@
+# Project conventions for Claude
+
+## Always commit the latest versions of generated artifacts after a test
+
+When a simulation, sweep, or netlist generator changes behaviour, **regenerate
+and commit any derived artifacts that downstream consumers rely on** — even if
+they were committed at an earlier point. Stale artifacts cause confusion when
+the user goes to inspect them and finds they don't match the current code.
+
+In this repo specifically, after any change to `test_closed_loop.py` that
+affects the netlist topology or component values:
+
+- Regenerate `regulator_<tube>.cir` via `python3 dump_netlists.py`
+- Regenerate `regulator_<tube>.asc` via `python3 netlist_to_asc.py <tube>` for
+  each tube in `TUBES`
+- Commit and push both alongside the code change
+- The `.cir` is what the user uses to verify their LTspice schematic; the
+  `.asc` is what they open for visualisation. Both must match the code that
+  produced the test results being reported.
+
+Same principle for any other generated outputs (`*.csv`, `*.png`, reports)
+that document a specific simulation run.


### PR DESCRIPTION
Adds a CLAUDE.md memory note: after any change to `test_closed_loop.py` that affects netlist topology or component values, regenerate and commit `regulator_<tube>.cir` and `regulator_<tube>.asc` alongside the code change. Avoids the stale-artifact problem we hit in PR #17.

https://claude.ai/code/session_017NCyg8LM8iXng2MzqG8KFd

---
_Generated by [Claude Code](https://claude.ai/code/session_017NCyg8LM8iXng2MzqG8KFd)_