### PR TITLE
CLAUDE.md: real circuit focus, not sim perfection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,25 @@
 # Project conventions for Claude
 
+## We are designing a real circuit, not perfecting a simulation
+
+The goal of every change is a circuit that can be built with real
+components, not a netlist that produces ever-cleaner numbers in
+ngspice. When proposing improvements, prefer simple, physically
+realisable solutions over elaborate spice tweaks. Examples:
+
+- A 3 dB difference in simulated phase margin doesn't matter if the
+  PCB and real op-amps will produce 10 dB of variation.
+- "Set Vos=0" tells us the loop's noiseless equilibrium, not what the
+  built circuit will do. Real op-amps have Vos; account for it.
+- A simulation that converges 50 ms faster but requires extra parts
+  costing £5 isn't an improvement for a hobby/replica build.
+- ngspice numerical stability issues (e.g. timestep collapse at switch
+  edges) are simulator artefacts. Don't optimise for them at the cost
+  of the real circuit's behaviour.
+
+When you find yourself solving a problem that wouldn't exist in
+hardware, stop and ask whether the problem is real.
+
 ## Always commit the latest versions of generated artifacts after a test
 
 When a simulation, sweep, or netlist generator changes behaviour, **regenerate


### PR DESCRIPTION
Adds a CLAUDE.md note: the goal is a buildable physical circuit, not a perfectly tuned simulation. Reminder to skip elaborate spice tweaks when real components would dominate the behaviour anyway, and to recognise simulator-specific numerical artefacts.

https://claude.ai/code/session_017NCyg8LM8iXng2MzqG8KFd

---
_Generated by [Claude Code](https://claude.ai/code/session_017NCyg8LM8iXng2MzqG8KFd)_